### PR TITLE
Add tray icon for Revolt

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -11,12 +11,11 @@ import { connectRPC, dropRPC } from './lib/discordRPC';
 import { autoLaunch } from './lib/autoLaunch';
 import { autoUpdate } from './lib/updater';
 
-let tray;
-const menu = electron.Menu;
-const contextMenu = Menu.buildFromTemplate([{icon: WindowIcon, label: 'Revolt', enabled: false}, /* revolt doesn't have credits page yet {label: 'Credits' click: require("shell").openExternal("https://revolt.chat")}*/ {label:'Quit Revolt', click: app.quit()}]);
-
 const WindowIcon = nativeImage.createFromPath(path.join(__dirname, "icon.png"));
 WindowIcon.setTemplateImage(true);
+
+let tray;
+const contextMenu = Menu.buildFromTemplate([{icon: WindowIcon, label: 'Revolt', enabled: false}, /* revolt doesn't have credits page yet {label: 'Credits' click: require("shell").openExternal("https://revolt.chat")}*/ { label:'Quit Revolt', click() { app.quit() } }]);
 
 onStart();
 autoUpdate();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import type { ConfigData } from './app';
 
-import { app, BrowserWindow, shell, ipcMain, nativeImage } from 'electron';
+import { app, BrowserWindow, Tray, Menu, shell, ipcMain, nativeImage } from 'electron';
 import windowStateKeeper from 'electron-window-state';
 import { RelaunchOptions } from 'electron/main';
 import { URL } from 'url';
@@ -11,6 +11,7 @@ import { connectRPC, dropRPC } from './lib/discordRPC';
 import { autoLaunch } from './lib/autoLaunch';
 import { autoUpdate } from './lib/updater';
 
+let tray
 const WindowIcon = nativeImage.createFromPath(path.join(__dirname, "icon.png"));
 WindowIcon.setTemplateImage(true);
 
@@ -98,7 +99,8 @@ function createWindow() {
 app.whenReady().then(async () => {
 	await firstRun();
 	createWindow();
-	
+	const icon = nativeImage.createFromPath('../desktop/build/icons/icon.png')
+        tray = new Tray(icon)
 	app.on('activate', function () {
 		if (BrowserWindow.getAllWindows().length === 0) createWindow()
 	})

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,10 @@ import { connectRPC, dropRPC } from './lib/discordRPC';
 import { autoLaunch } from './lib/autoLaunch';
 import { autoUpdate } from './lib/updater';
 
-let tray
+let tray;
+const menu = electron.Menu;
+const contextMenu = Menu.buildFromTemplate([{icon: WindowIcon, label: 'Revolt', enabled: false}, /* revolt doesn't have credits page yet {label: 'Credits' click: require("shell").openExternal("https://revolt.chat")}*/ {label:'Quit Revolt', click: app.quit();}
+					    
 const WindowIcon = nativeImage.createFromPath(path.join(__dirname, "icon.png"));
 WindowIcon.setTemplateImage(true);
 
@@ -99,8 +102,9 @@ function createWindow() {
 app.whenReady().then(async () => {
 	await firstRun();
 	createWindow();
-	const icon = nativeImage.createFromPath('../desktop/build/icons/icon.png')
-        tray = new Tray(icon)
+        tray = new Tray(WindowIcon)
+	tray.setToolTip("Revolt")
+	tray.setContextMenu(contextMenu)
 	app.on('activate', function () {
 		if (BrowserWindow.getAllWindows().length === 0) createWindow()
 	})

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ const WindowIcon = nativeImage.createFromPath(path.join(__dirname, "icon.png"));
 WindowIcon.setTemplateImage(true);
 
 let tray;
-const contextMenu = Menu.buildFromTemplate([{icon: WindowIcon, label: 'Revolt', enabled: false}, /* revolt doesn't have credits page yet {label: 'Credits' click: require("shell").openExternal("https://revolt.chat")}*/ { label:'Quit Revolt', click() { app.quit() } }]);
+const contextMenu = Menu.buildFromTemplate([{ icon: WindowIcon, label: `Revolt : Version: ${version}`, enabled: false }, {  label: 'Separator', type: 'separator' }, { label: 'Contribute', click() { shell.openExternal("https://github.com/revoltchat") } }, /* revolt doesn't have credits page yet { label: 'Credits', click() { shell.openExternal("https://revolt.chat") } },*/ {  label: 'Separator', type: 'separator' }, { label:'Quit Revolt', click() { app.quit() } }]);
 
 onStart();
 autoUpdate();

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,8 +13,8 @@ import { autoUpdate } from './lib/updater';
 
 let tray;
 const menu = electron.Menu;
-const contextMenu = Menu.buildFromTemplate([{icon: WindowIcon, label: 'Revolt', enabled: false}, /* revolt doesn't have credits page yet {label: 'Credits' click: require("shell").openExternal("https://revolt.chat")}*/ {label:'Quit Revolt', click: app.quit();}
-					    
+const contextMenu = Menu.buildFromTemplate([{icon: WindowIcon, label: 'Revolt', enabled: false}, /* revolt doesn't have credits page yet {label: 'Credits' click: require("shell").openExternal("https://revolt.chat")}*/ {label:'Quit Revolt', click: app.quit();}]);
+
 const WindowIcon = nativeImage.createFromPath(path.join(__dirname, "icon.png"));
 WindowIcon.setTemplateImage(true);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import { autoUpdate } from './lib/updater';
 
 let tray;
 const menu = electron.Menu;
-const contextMenu = Menu.buildFromTemplate([{icon: WindowIcon, label: 'Revolt', enabled: false}, /* revolt doesn't have credits page yet {label: 'Credits' click: require("shell").openExternal("https://revolt.chat")}*/ {label:'Quit Revolt', click: app.quit();}]);
+const contextMenu = Menu.buildFromTemplate([{icon: WindowIcon, label: 'Revolt', enabled: false}, /* revolt doesn't have credits page yet {label: 'Credits' click: require("shell").openExternal("https://revolt.chat")}*/ {label:'Quit Revolt', click: app.quit()}]);
 
 const WindowIcon = nativeImage.createFromPath(path.join(__dirname, "icon.png"));
 WindowIcon.setTemplateImage(true);


### PR DESCRIPTION
This pull request is intended to add tray icon for Revolt. This is going to add some variables for tray icon and a menu which allows the user to quit from app. Also partly solves #2 by adding tray icon.