### PR TITLE
feat: add option to specify a custom build URL in config.json

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -45,6 +45,9 @@ export function onStart() {
 }
 
 export function getBuildURL() {
+	const buildURL = store.get('buildURL', undefined);
+	if (buildURL) return buildURL;
+
 	const build: 'stable' | 'nightly' | 'dev' = getConfig().build;
 
 	switch (build) {


### PR DESCRIPTION
This checks the config file for a `buildURL` option and uses it instead of the official one. I don't think there is any other way to connect to a custom instance without recompiling, correct me if I'm wrong. 