### PR TITLE
fix: app closure for macOS users in window close event

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,22 +3,22 @@ import type { ConfigData } from "./app";
 import {
     app as App,
     BrowserWindow,
-    shell,
-    ipcMain,
-    nativeImage,
-    Tray,
     Menu,
     MenuItem,
+    Tray,
+    ipcMain,
+    nativeImage,
+    shell,
 } from "electron";
-import { execFile } from "node:child_process";
 import windowStateKeeper from "electron-window-state";
 import { RelaunchOptions } from "electron/main";
-import { URL } from "node:url";
+import { execFile } from "node:child_process";
 import path from "node:path";
+import { URL } from "node:url";
 
-import { firstRun, getConfig, store, onStart, getBuildURL } from "./lib/config";
-import { connectRPC, dropRPC } from "./lib/discordRPC";
 import { autoLaunch } from "./lib/autoLaunch";
+import { firstRun, getBuildURL, getConfig, onStart, store } from "./lib/config";
+import { connectRPC, dropRPC } from "./lib/discordRPC";
 import { autoUpdate } from "./lib/updater";
 
 let forceQuit = false;
@@ -103,6 +103,7 @@ function createWindow() {
             !forceQuit &&
             !app.shouldQuit &&
             !app.shouldRelaunch &&
+            process.platform !== "darwin" &&
             getConfig().minimiseToTray
         ) {
             event.preventDefault();


### PR DESCRIPTION
## Please make sure to check the following tasks before opening and submitting a PR

* [x] I understand and have followed the [contribution guide](https://github.com/revoltchat/revolt/discussions/282)
* [x] I have tested my changes locally and they are working as intended
* [x] These changes do not have any notable side effects on other Revolt projects

this pr allows the application to close instantly when the "Quit" option is selected in the dock on Revolt (the application will now close immediately upon clicking "quit")
